### PR TITLE
registerDefaults: does not save to disk

### DIFF
--- a/GroundControl/NSUserDefaults+GroundControl.m
+++ b/GroundControl/NSUserDefaults+GroundControl.m
@@ -72,7 +72,9 @@
 {
     AFPropertyListRequestOperation *requestOperation = [[AFPropertyListRequestOperation alloc] initWithRequest:urlRequest];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
-        [self registerDefaults:responseObject];
+        // registerDefaults: does not save to disk!
+        // to access settings when URL request fails (network unavailable), set as normal defaults.
+        [self setValuesForKeysWithDictionary:responseObject];
         [self synchronize];
         
         if (success) {


### PR DESCRIPTION
`-[NSUserDefaults registerDefaults:]` does **not** write to disk, so if the network request fails, then the values from a previously successful call are not available.

I've replaced the `registerDefaults:` call with `setValuesForKeysWithDictionary:`, so the only time a default setting will be nil is if on the initial app launch the network request fails.
