### PR TITLE
Fix Nodejs Snippet for Express > 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ var host = "127.0.0.1"
 var port = 8080
 
 var app = express()
-app.use(app.router)
 
 app.get("/", function(request, response) { 
         response.send(plist.build(


### PR DESCRIPTION
Something really small, but when using Express 4.x you will have an error with the current Node.js snippet

```
Error: 'app.router' is deprecated!
Please see the 3.x to 4.x migration guide for details on how to update your app.
    at Function.Object.defineProperty.get (/Users/jerome.miglino/Workspace/NodeJS/node_modules/express/lib/application.js:83:13)
    at Object.<anonymous> (/Users/jerome.miglino/Workspace/NodeJS/plist.js:8:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
```

According to https://github.com/visionmedia/express/wiki/Migrating-from-3.x-to-4.x you just need to remove the `app.use(app.router)` ;-)
